### PR TITLE
[AArch64] Peephole optimization to remove redundant csel instructions

### DIFF
--- a/llvm/test/CodeGen/AArch64/peephole-csel.ll
+++ b/llvm/test/CodeGen/AArch64/peephole-csel.ll
@@ -6,7 +6,7 @@ define void @peephole_csel(ptr %dst, i1 %0, i1 %cmp) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    tst w2, #0x1
 ; CHECK-NEXT:    mov w8, #1 // =0x1
-; CHECK-NEXT:    csel x9, xzr, xzr, eq
+; CHECK-NEXT:    mov x9, xzr
 ; CHECK-NEXT:    tst w1, #0x1
 ; CHECK-NEXT:    csel x8, x8, x9, eq
 ; CHECK-NEXT:    str x8, [x0]

--- a/llvm/test/CodeGen/AArch64/peephole-csel.mir
+++ b/llvm/test/CodeGen/AArch64/peephole-csel.mir
@@ -19,7 +19,7 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64 = COPY $x1
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr64 = COPY $x0
     ; CHECK-NEXT: $xzr = ANDSXri [[COPY]], 0, implicit-def $nzcv
-    ; CHECK-NEXT: [[CSELXr:%[0-9]+]]:gpr64 = CSELXr [[COPY1]], [[COPY1]], 0, implicit $nzcv
+    ; CHECK-NEXT: [[ORRXrs:%[0-9]+]]:gpr64 = ORRXrs $xzr, [[COPY1]], 0
     ; CHECK-NEXT: RET_ReallyLR
     %3:gpr64 = COPY $x1
     %4:gpr64 = COPY $x0
@@ -46,7 +46,7 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32 = COPY $w1
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32 = COPY $w0
     ; CHECK-NEXT: $wzr = ANDSWri [[COPY]], 0, implicit-def $nzcv
-    ; CHECK-NEXT: [[CSELWr:%[0-9]+]]:gpr32 = CSELWr [[COPY1]], [[COPY1]], 0, implicit $nzcv
+    ; CHECK-NEXT: [[ORRWrs:%[0-9]+]]:gpr32 = ORRWrs $wzr, [[COPY1]], 0
     ; CHECK-NEXT: RET_ReallyLR
     %3:gpr32 = COPY $w1
     %4:gpr32 = COPY $w0


### PR DESCRIPTION
Given a sequence such as

  %8:gpr64 = COPY $xzr
  %10:gpr64 = COPY $xzr
  %11:gpr64 = CSELXr %8:gpr64, %10:gpr64, 0, implicit $nzcv

`PeepholeOptimizer::foldRedundantCopy` led to the creation of select instructions where both inputs were the same register:

  %11:gpr64 = CSELXr %8:gpr64, %8:gpr64, 0, implicit $nzcv

This change adds a later peephole optimization that replaces such selects with unconditional moves.